### PR TITLE
Add archived tasks section to roadmap and small fixes

### DIFF
--- a/roadmap.qmd
+++ b/roadmap.qmd
@@ -20,6 +20,12 @@ results = vote.run_election('./roadmap/votes', 5, "./roadmap/tasks.csv")
 
 df = results["avg_table"]
 
+# Keep non-archived tasks only
+df = df[df['Archived_on'].isna()]
+
+if "Archived_on" in df.columns:
+    df = df.drop(columns=["Archived_on"])
+
 # Move high priority to top
 df["highpriority"] = df["Task"].apply(lambda x: 0 if x in results["winners"] else 1)
 df = df.sort_values(by="highpriority").drop(columns=["highpriority"])
@@ -34,7 +40,6 @@ print("""
 Features with 🚨 symbol were voted as top priority with StarVote. Priority column is an average of votes for every feature.
 
 """)
-
 show(df, paging=False)
 
 print("""
@@ -49,4 +54,16 @@ votes_dict = vote.get_votes('./roadmap/votes')
 votes_df = pd.DataFrame(votes_dict)
 votes_df = votes_df.fillna(0)
 show(votes_df, paging=False)
+
+print("""
+## Archived Tasks
+
+Archived tasks
+
+""")
+
+archived_tasks_df = vote.get_archived_tasks_table('./roadmap/tasks.csv')
+archived_tasks_df.reset_index(drop=True, inplace=True)
+
+show(archived_tasks_df)
 ```

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -6,3 +6,8 @@ Every voter has a .csv file with votes to cast.
 To create a new voter, copy and rename tasks.csv in `votes/` folder, then add a `Vote` column in csv and set your voted priority (0-100) for a feature.
 
 New features must be added to `tasks.csv` before casting any vote.
+
+You can run `vote.py` from repository root
+```
+python3 vote.py
+```

--- a/roadmap/tasks.csv
+++ b/roadmap/tasks.csv
@@ -1,31 +1,32 @@
-Category,Task
-Customization,Appearance Swapper 👗 - 3 preset outfit toggle
-Interaction,Avatar Calibration 🤖 - Height/Scale adjustment sliders
-Customization,Build Duplicator 🏗️ - Object copy/paste tool
-Audio,Directional VOIP 🔊 - Distance-based voice channel clarity
-Interface,Emergency Menu 📋 - Basic pause/glitch recovery panel
-Social,Emote Wheel 😃 - 6-slot expression selector
-Social,Friend List 👥 - Add/Remove contact system
-Systems,Host Handoff 🏠 - Basic migration protocol
-Simulation,Hunger Meter 🍎 - Time-based depletion
-Production,Investor Demo 💵 - 5-minute feature showcase
-Economy,Item Trade 💰 - Direct player exchange UI
-Production,Level Streamer 🚀 - Section load/unload trigger
-Audio,Lip Sync Prototype 🔊 - Basic viseme (FACS) triggers from audio input
-Production,Model Importer 🎨 - FBX/GLB load test
-Simulation,Mood Indicator 😊 - Basic emotion states UI
-Networking,Multi-User Instance 🌐 - 10-player test environment
-Economy,NPC Patrol 🤖 - Predefined path walking
-Networking,Object State Sync 🔄 - Position/Rotation transmission
-Production,Poly Budget Tool 🖌️ - Triangle counter display
-Networking,Room Transition 🔄 - Basic join/leave mechanics
-Systems,Rule Toggles ⚖️ - 3 configurable parameters
-Systems,Script Console 💻 - Runtime command input
-Interaction,Script Editing Sandbox 💻 - On-the-fly gameplay scripting
-Simulation,Skill Progress 📈 - Experience counter display
-Audio,Voice Chat 🔊 - Chat with voice
-Interface,Text Chat Core 💬 - Persistent message display
-Customization,UGC Upload 🛠️ - Basic model/texture submission
-Interaction,VR UI Selection 🎯 - Laser pointer object interaction
-Social,VRM Trial 🕶️ - Single-avatar import test
-Economy,Wall Painter 🏡 - Single-surface color tool
+Category,Task,Archived_on
+Customization,Appearance Swapper 👗 - 3 preset outfit toggle,null
+Interaction,Avatar Calibration 🤖 - Height/Scale adjustment sliders,null
+Customization,Build Duplicator 🏗️ - Object copy/paste tool,null
+Audio,Directional VOIP 🔊 - Distance-based voice channel clarity,null
+Interface,Emergency Menu 📋 - Basic pause/glitch recovery panel,null
+Social,Emote Wheel 😃 - 6-slot expression selector,null
+Social,Friend List 👥 - Add/Remove contact system,null
+Systems,Host Handoff 🏠 - Basic migration protocol,null
+Simulation,Hunger Meter 🍎 - Time-based depletion,null
+Production,Investor Demo 💵 - 5-minute feature showcase,null
+Economy,Item Trade 💰 - Direct player exchange UI,null
+Production,Level Streamer 🚀 - Section load/unload trigger,null
+Audio,Lip Sync Prototype 🔊 - Basic viseme (FACS) triggers from audio input,null
+Production,Model Importer 🎨 - FBX/GLB load test,null
+Simulation,Mood Indicator 😊 - Basic emotion states UI,null
+Networking,Multi-User Instance 🌐 - 10-player test environment,null
+Economy,NPC Patrol 🤖 - Predefined path walking,null
+Networking,Object State Sync 🔄 - Position/Rotation transmission,null
+Production,Poly Budget Tool 🖌️ - Triangle counter display,null
+Networking,Room Transition 🔄 - Basic join/leave mechanics,null
+Systems,Rule Toggles ⚖️ - 3 configurable parameters,null
+Systems,Script Console 💻 - Runtime command input,null
+Interaction,Script Editing Sandbox 💻 - On-the-fly gameplay scripting,null
+Simulation,Skill Progress 📈 - Experience counter display,null
+Audio,Voice Chat 🔊 - Chat with voice,null
+Interface,Text Chat Core 💬 - Persistent message display,null
+Customization,UGC Upload 🛠️ - Basic model/texture submission,null
+Interaction,VR UI Selection 🎯 - Laser pointer object interaction,null
+Social,VRM Trial 🕶️ - Single-avatar import test,null
+Economy,Wall Painter 🏡 - Single-surface color tool,null
+Systems,Uro 🌐 - Uro new Elixir/Nextjs server,2025-03-18


### PR DESCRIPTION
- Add `Archived_on` column in `roadmap/tasks.csv`
- Display archived tasks in roadmap page
- Filter ballots keys to remove archived tasks from election. This ensures voters can't vote on old archived tasks, even if they add an entry in their csv file