### PR TITLE
Mark Three.js ADRs superseded; defer observer to ship VR first; drop Playwright

### DIFF
--- a/decisions/20260425-build-cache-test-pipeline.md
+++ b/decisions/20260425-build-cache-test-pipeline.md
@@ -45,7 +45,7 @@ build-godot (runs when sources change)
 headless-tests (runs after build-godot)
   ├── download-artifact: godot-headless-bin
   ├── start zone server (downloaded binary, --headless)
-  ├── run Playwright matrix (Four Roles × phases 1 and 2)
+  ├── run shell-based matrix (GO + GP, phases 1 and 2; no Playwright)
   └── report results
 ```
 
@@ -75,10 +75,10 @@ developer's local `bin/` directory:
 # docker-compose.test.yml
 services:
   test-runner:
-    image: mcr.microsoft.com/playwright:v1.44.0-jammy
+    image: ubuntu:24.04
     volumes:
       - ../multiplayer-fabric-godot/bin/godot.linuxbsd.editor.dev.x86_64:/godot/godot:ro
-      - ../multiplayer-fabric-zone-backend/frontend:/app
+      - ../tests:/tests
     environment:
       GODOT_BIN: /godot/godot
       ZONE_HOST: zone-server
@@ -109,7 +109,8 @@ headless-tests:
 ```
 
 `headless_tests.yml` is a new workflow file in the same directory. It
-downloads the artifact, starts the zone server, and runs Playwright.
+downloads the artifact, starts the zone server, and runs the shell-based
+matrix (`bash run_matrix.sh`). No Playwright, no browser engine.
 
 The branch protection rule applies to the `multiplayer-fabric` branch of
 `github.com/V-Sekai-fire/multiplayer-fabric-godot` — the assembled branch
@@ -122,15 +123,14 @@ Settings → Branches → Add rule:
   Branch name pattern: multiplayer-fabric
   ✓ Require status checks to pass before merging
     ✓ 🧪 Headless / GO — Godot observer
-    ✓ 🧪 Headless / TO — Three.js observer
     ✓ 🧪 Headless / GP — Godot player
-    ✓ 🧪 Headless / TP — Three.js player
-    ✓ 🧪 Headless / GO+TO — dual observer cross-check
+    ✓ 🧪 Headless / GO+GP — dual cross-check
 ```
 
-Five checks: four single-client (one per role) and the key dual-client
-cross-check. The remaining five dual-client pairs are informational — they
-run but do not block merge until all four single-client roles are green.
+Three checks: two single-role (GO, GP) and one dual cross-check. Three.js
+roles are gone (the browser client is superseded), and the observer (GO)
+itself is currently deferred while the VR client lands; checks become live
+once the matrix unfreezes.
 
 ### CI artifact retention
 

--- a/decisions/20260425-dual-client-test.md
+++ b/decisions/20260425-dual-client-test.md
@@ -1,8 +1,16 @@
 # Dual-Client Test: Native Desktop and Three.js Against One Godot Zone Server
 
-- Status: accepted
+Superseded by: [20260425-headless-test-matrix.md](20260425-headless-test-matrix.md)
+
+- Status: superseded — not being built
 - Deciders: V-Sekai, fire
 - Tags: V-Sekai, Testing, Playwright, Godot, Threejs, DualClient, ZoneServer, 20260425-dual-client-test
+
+> **Why superseded:** the design pairs a Godot native client with a Three.js
+> browser client. The Three.js client is no longer being built (see
+> [20260425-threejs-webgpu-zone-client.md](20260425-threejs-webgpu-zone-client.md)).
+> Dual-client coverage now lives in the headless test matrix as the GO+GP pair
+> ([20260425-headless-test-matrix.md](20260425-headless-test-matrix.md)).
 
 ## The Context
 
@@ -135,7 +143,7 @@ client test must use the real server.
 
 ## Status
 
-Status: Accepted
+Status: Superseded by [20260425-headless-test-matrix.md](20260425-headless-test-matrix.md). Not being built.
 
 ## Decision Makers
 

--- a/decisions/20260425-godot-observer.md
+++ b/decisions/20260425-godot-observer.md
@@ -2,9 +2,9 @@
 
 Supersedes: [20260425-threejs-observer.md](20260425-threejs-observer.md)
 
-- Status: accepted
+- Status: deferred — not building yet; focus is on VR ([20260425-godot-player.md](20260425-godot-player.md)) first
 - Deciders: V-Sekai, fire
-- Tags: V-Sekai, Godot, WebTransport, Observer, ZoneServer, Headless, CI, 20260425-godot-observer
+- Tags: V-Sekai, Godot, WebTransport, Observer, ZoneServer, Headless, CI, Deferred, 20260425-godot-observer
 
 ## The Context
 
@@ -84,8 +84,8 @@ No separate datagram parser is needed. `FabricMultiplayerPeer` handles the
 [{"id": 1, "pos": {"x": 0.0, "y": 0.0, "z": 0.0}}, ...]
 ```
 
-Used by Playwright and CI to assert `entities.length > 0` without parsing
-Godot stdout.
+Used by shell-based CI orchestration (no browser engine, no Playwright) to
+assert `entities.length > 0` without parsing Godot stdout.
 
 ## The Downsides
 
@@ -100,7 +100,7 @@ from the C++ implementation. The Godot headless path removes that gap.
 
 ## Status
 
-Status: Accepted
+Status: Deferred. Not building yet — focus is on the VR client ([20260425-godot-player.md](20260425-godot-player.md)) first. The design here remains valid and will be picked back up after the VR pass condition lands.
 
 ## Decision Makers
 

--- a/decisions/20260425-godot-player.md
+++ b/decisions/20260425-godot-player.md
@@ -31,7 +31,7 @@ native taskweft, and the godot-sandbox RISC-V guest already tested on desktop.
 | Reach:       | +1     | PCVR headsets and desktop operators; native performance; no browser install. |
 | Impediment:  | +1     | Without entity control, the operator can only observe — cannot spawn jellyfish or trigger behavior changes. |
 | Stakeholder: | +1     | Creator market and VR demo both depend on interactive entity control. |
-| **Total**    | **+3** | Schedule soon; unblock observer (Phase 1 GO) first. |
+| **Total**    | **+3** | Active focus. Observer ([20260425-godot-observer.md](20260425-godot-observer.md)) is deferred so we ship VR first. |
 
 ## Design
 
@@ -133,7 +133,7 @@ Status: Draft
 
 [@threejsplayer]: [20260425-threejs-player.md](20260425-threejs-player.md) — superseded Three.js Stage 2.
 
-[@godotobserver]: [20260425-godot-observer.md](20260425-godot-observer.md) — Phase 1; must pass GO test before this ships.
+[@godotobserver]: [20260425-godot-observer.md](20260425-godot-observer.md) — deferred; VR client ships first, observer follows.
 
 [@operatorcamera]: [20260425-operator-camera-2-5d.md](20260425-operator-camera-2-5d.md) — twist/swing [0,1] camera; Survey and Follow modes.
 

--- a/decisions/20260425-godot-web-client-webtransport.md
+++ b/decisions/20260425-godot-web-client-webtransport.md
@@ -1,5 +1,14 @@
 # Godot Web Client WebTransport: Implementation Record
 
+> **Note (active focus):** the browser/web client direction is currently
+> **deferred** while we ship VR ([20260425-godot-player.md](20260425-godot-player.md))
+> first. Browser observation is SOMEDAY (per
+> [20260425-godot-observer.md](20260425-godot-observer.md)), and no new
+> Playwright work is being added — the spec referenced below is a one-time
+> historical PoC that proved the bug fixes recorded here. Future test
+> orchestration is shell-based (see
+> [20260425-headless-test-matrix.md](20260425-headless-test-matrix.md)).
+
 ## The Context
 
 The Infinite Aquarium / Virtual Creator Market targets web browsers as the

--- a/decisions/20260425-headless-test-matrix.md
+++ b/decisions/20260425-headless-test-matrix.md
@@ -1,14 +1,20 @@
-# Headless Test Matrix: Four Client Roles Against One Zone Server
+# Headless Test Matrix: Two Client Roles Against One Zone Server
 
-- Status: accepted
+- Status: deferred — focus is on VR ([20260425-godot-player.md](20260425-godot-player.md)) first; matrix resumes after the observer ([20260425-godot-observer.md](20260425-godot-observer.md)) lands
 - Deciders: V-Sekai, fire
-- Tags: V-Sekai, Testing, Headless, Playwright, Godot, Threejs, ZoneServer, 20260425-headless-test-matrix
+- Tags: V-Sekai, Testing, Headless, Godot, ZoneServer, Deferred, 20260425-headless-test-matrix
 
 ## The Context
 
-Two clients (Godot native, Three.js WebGPU) each have two roles (observer,
-player). Testing them headless first means no VR hardware and no display
-required. Tests follow a three-stage promotion path:
+The Godot native client has two roles (observer, player). The Three.js client
+is no longer being built (see
+[20260425-threejs-webgpu-zone-client.md](20260425-threejs-webgpu-zone-client.md)),
+so the matrix is now Godot-only. Both phases below depend on the observer
+([20260425-godot-observer.md](20260425-godot-observer.md)), which is deferred
+while we ship the VR client first — so this matrix is also deferred. Design
+content is preserved for when work resumes. Testing them headless first means
+no VR hardware and no display required. Tests follow a three-stage promotion
+path:
 
 ```
 local Docker  →  CI headless  →  VR hardware
@@ -23,79 +29,72 @@ The zone server is always the Godot native binary run with `--headless`.
 
 ## The Problem Statement
 
-Four client roles × two clients = four test subjects. No matrix exists that
-verifies all four connect to one server and that player actions are reflected
-in observer state. Tests must pass locally in Docker before being wired to CI,
-and must pass in CI before any VR hardware is involved.
+Two client roles (observer, player) on the Godot native client. No matrix
+exists that verifies both connect to one server and that player actions are
+reflected in observer state. Tests must pass locally in Docker before being
+wired to CI, and must pass in CI before any VR hardware is involved.
 
 ## CRIS Score
 
 | Factor       | Score  | Evidence |
 | ------------ | ------ | -------- |
-| Complexity:  | +1     | Three of the four roles are already partially implemented. headless_log_observer.gd exists. Playwright handles Three.js. |
+| Complexity:  | +1     | Both roles reuse `FabricMultiplayerPeer` and `fabric_client.gd`. `headless_log_observer.gd` already exists for the observer path. Shell-only orchestration; no browser engine, no JS test runner. |
 | Reach:       | +1     | Runs in CI on every push, no hardware dependency. |
-| Impediment:  | +1     | Without this matrix, a server-side regression could break one client silently. |
+| Impediment:  | +1     | Without this matrix, a server-side regression could break the client silently. |
 | Stakeholder: | +1     | Pass condition for the aquarium demo requires two simultaneous observers. |
 | **Total**    | **+4** | Build now. |
 
 ## Design
 
-### Four roles
+### Two roles
 
 | ID | Client | Role | How to run headless |
 | -- | ------ | ---- | ------------------- |
 | GO | Godot native | Observer | `--headless --path demo observer.tscn` via `headless_log_observer.gd` |
 | GP | Godot native | Player | `--headless --path demo observer.tscn -- --send-player` (new flag, writes CH_PLAYER) |
-| TO | Three.js | Observer | Playwright Chromium, reads `window.__entities` |
-| TP | Three.js | Player | Playwright Chromium, reads `window.__entities` + calls `window.__sendPlayer()` |
 
-### Phase 1 — single-client tests (four tests, run serially)
+### Phase 1 — single-client tests (two tests, run serially)
 
 Each test: start zone server → start one client → wait for entities → assert count > 0 → stop.
 
 ```
-server + GO  →  entity count > 0  (headless_log_observer.gd, stdout parse)
+server + GO  →  entity count > 0  (headless_log_observer.gd, --dump-json)
 server + GP  →  entity count > 0, CH_PLAYER sent, server ACKs
-server + TO  →  window.__entities.length > 0 after WebTransport connect
-server + TP  →  window.__entities.length > 0, window.__sendPlayer() sends datagram
 ```
 
-### Phase 2 — dual-client tests (six pairs, run serially)
+### Phase 2 — dual-client test (one pair)
 
-Each test: start zone server → start two clients → compare entity ID sets → assert equal.
+Start zone server → start GO and GP simultaneously → assert GP's input is
+reflected in GO's next observed frame.
 
 ```
-GO + TO  →  same entity IDs observed (Godot stdout == Three.js window.__entities)
 GO + GP  →  GP action reflected in GO's next frame
-GO + TP  →  TP action reflected in GO's next frame
-TO + TP  →  TP action visible in TO's window.__entities
-GO + TP + TO  →  three-way cross-check (Phase 3)
-GP + TP  →  both players' actions reflected in each other's observer
 ```
 
 ### Local Docker run (required before CI)
 
 The existing `multiplayer-fabric-hosting` Compose stack already runs a zone
-server (`zone-server` service). Add a test service that mounts the test
-scripts and runs Playwright inside the same Docker network:
+server (`zone-server` service). Add a test service that runs the Godot
+binary headlessly inside the same Docker network — no Playwright, no
+browser, no Node runtime:
 
 ```yaml
 # docker-compose.test.yml
 services:
   test-runner:
-    image: mcr.microsoft.com/playwright:v1.44.0-jammy
+    image: ubuntu:24.04
     depends_on:
       zone-server:
         condition: service_healthy
     volumes:
-      - ./multiplayer-fabric-zone-backend/frontend:/app
       - ./multiplayer-fabric-godot/bin:/godot
-    working_dir: /app
+      - ./tests:/tests
+    working_dir: /tests
     environment:
       ZONE_HOST: zone-server
       ZONE_PORT: "17500"
       GODOT_BIN: /godot/godot.linuxbsd.editor.dev.x86_64
-    command: npx playwright test headless_matrix --project=chromium
+    command: bash run_matrix.sh
     network_mode: host   # shares zone-server port
 ```
 
@@ -109,34 +108,23 @@ docker compose -f multiplayer-fabric-hosting/docker-compose.yml \
 
 A green local Docker run is the gate before the CI job is added.
 
-### Playwright orchestration
+### Shell orchestration
 
-```ts
-async function startZoneServer(): Promise<ChildProcess> {
-  const proc = spawn(GODOT_BIN, ["--headless", "--path", ZONE_PROJECT, "scenes/zone_server.tscn"]);
-  await waitForPort(17500);  // poll until server accepts TCP
-  return proc;
-}
+`run_matrix.sh` starts the Godot binaries, polls for the zone-server port,
+diffs the JSON dumps, and exits non-zero on mismatch. No browser engine, no
+JavaScript test runner — just GDScript flags and `jq`.
 
-async function startGodotObserver(dumpPath: string): Promise<ChildProcess> {
-  return spawn(GODOT_BIN, [
-    "--headless", "--path", DEMO_PROJECT,
-    "--script", "scripts/headless_log_observer.gd",
-    "--", `--dump-json=${dumpPath}`
-  ]);
-}
-
-async function threejsObserver(page: Page): Promise<Entity[]> {
-  await page.waitForFunction(
-    () => (window as any).__entities?.length > 0, { timeout: 15_000 }
-  );
-  return page.evaluate(() => (window as any).__entities);
-}
+```sh
+"$GODOT_BIN" --headless --path "$DEMO_PROJECT" \
+  --script scripts/headless_log_observer.gd \
+  -- --dump-json=/tmp/go.json --frames=600
 ```
+
+Same shape for the GP role with `--send-player` instead of `--dump-json`.
 
 ### Missing pieces before Phase 1
 
-Three items need implementing before the matrix runs:
+Two items need implementing before the matrix runs:
 
 1. `headless_log_observer.gd` — add `--dump-json=<path>` flag that writes the
    final entity list as JSON on exit (currently only prints to stdout).
@@ -144,18 +132,13 @@ Three items need implementing before the matrix runs:
 2. Godot player headless — a `--send-player` flag in `fabric_client.gd` or a
    new script that sends one CH_PLAYER datagram after connecting, then exits.
 
-3. Three.js `window.__sendPlayer()` — the Stage 2 CH_PLAYER write path
-   ([20260425-threejs-player.md](20260425-threejs-player.md)) must expose this
-   function before Phase 2 TP tests can run.
-
-Phase 1 GO and TO tests can run today with `headless_log_observer.gd` stdout
-parsing and the existing Three.js observer Playwright spec.
+Phase 1 GO can run today with `headless_log_observer.gd` stdout parsing.
 
 ## The Downsides
 
-Six pairs × server startup (~3 s each) = ~20 s of CI wall time for Phase 2.
-The server must bind a fresh port for each test to avoid inter-test interference;
-or tests run serially with a single shared server.
+One pair × server startup (~3 s) for Phase 2. The server must bind a fresh
+port for each test to avoid inter-test interference; or tests run serially
+with a single shared server.
 
 The Docker gate adds one manual step before CI promotion. A developer who skips
 the Docker run and pushes directly can still break CI; the gate is enforced by
@@ -169,7 +152,7 @@ real server binary.
 
 ## Status
 
-Status: Accepted
+Status: Deferred. Not building yet — focus is on the VR client ([20260425-godot-player.md](20260425-godot-player.md)) first; this matrix resumes after the observer ([20260425-godot-observer.md](20260425-godot-observer.md)) lands. Design (shell-based, no Playwright) preserved for that resumption.
 
 ## Decision Makers
 
@@ -177,8 +160,8 @@ Status: Accepted
 
 ## Further Reading
 
-[@dual_client]: [20260425-dual-client-test.md](20260425-dual-client-test.md) — dual observer design.
+[@godot_observer]: [20260425-godot-observer.md](20260425-godot-observer.md) — Godot `--headless` observer (GO role).
 
-[@threejs_observer]: [20260425-threejs-observer.md](20260425-threejs-observer.md) — Three.js observer client.
+[@godot_player]: [20260425-godot-player.md](20260425-godot-player.md) — Godot native PCVR player (GP role).
 
-[@threejs_player]: [20260425-threejs-player.md](20260425-threejs-player.md) — Three.js player client (Stage 2).
+[@dual_client]: [20260425-dual-client-test.md](20260425-dual-client-test.md) — superseded; coverage merged into this matrix as the GO+GP pair.

--- a/decisions/20260425-jellyfish-game.md
+++ b/decisions/20260425-jellyfish-game.md
@@ -79,16 +79,20 @@ property is a second milestone, not a prerequisite for the pass condition.
 
 ## Client strategy
 
-The Godot wasm32/wasm64 web export is dropped. Two clients replace it:
+The Godot wasm32/wasm64 web export is dropped. Active client surface is Godot-native:
 
 Godot native PCVR client handles VR presence, jellyfish creation, and entity
 control. It uses the xr-grid project with OpenXR and the picoquic WebTransport
-backend.
+backend. See [20260425-godot-player.md](20260425-godot-player.md).
 
-Three.js WebGPU client handles browser access, spectating, and the operator
-view. It connects via the browser's WebTransport API and parses CH_INTEREST
-datagrams directly. See
-[20260425-threejs-webgpu-zone-client.md](20260425-threejs-webgpu-zone-client.md).
+Godot `--headless` observer (operator and CI smoke-test paths) is **deferred**
+until the VR client ships. The design — reusing `FabricMultiplayerPeer` and
+`fabric_client.gd`, no separate parser, no TypeScript — remains valid; see
+[20260425-godot-observer.md](20260425-godot-observer.md).
+
+A browser client is SOMEDAY; the Three.js WebGPU design
+([20260425-threejs-webgpu-zone-client.md](20260425-threejs-webgpu-zone-client.md))
+is superseded and not being built.
 
 ## In Core and Done by Us
 
@@ -99,7 +103,7 @@ datagrams directly. See
   — RECTGTN species domains
 - `multiplayer-fabric-zone-backend` — `GET /shards/:id/assets`, ReBAC, Uro
 - xr-grid project — Godot native PCVR client, jellyfish creation
-- Three.js WebGPU client — browser observer, operator overlay
+- `headless_log_observer.gd` — Godot `--headless` observer (deferred; ships after VR)
 
 ## Status
 

--- a/decisions/20260425-threejs-observer.md
+++ b/decisions/20260425-threejs-observer.md
@@ -99,7 +99,7 @@ Stage 1 would delay shipping the operator view.
 
 ## Status
 
-Status: Accepted
+Status: Superseded by [20260425-godot-observer.md](20260425-godot-observer.md). Not being built.
 
 ## Decision Makers
 

--- a/decisions/20260425-threejs-player.md
+++ b/decisions/20260425-threejs-player.md
@@ -87,7 +87,7 @@ implementation. Stage 2 is the browser peer; it does not replace the native clie
 
 ## Status
 
-Status: Draft
+Status: Superseded by [20260425-godot-player.md](20260425-godot-player.md). Not being built.
 
 ## Decision Makers
 

--- a/decisions/20260425-threejs-webgpu-zone-client.md
+++ b/decisions/20260425-threejs-webgpu-zone-client.md
@@ -1,6 +1,8 @@
 # Three.js WebGPU Client Against the Godot Zone Server
 
-- Status: Superseded by [20260425-godot-observer.md](20260425-godot-observer.md) and [20260425-godot-player.md](20260425-godot-player.md)
+Superseded by: [20260425-godot-observer.md](20260425-godot-observer.md) and [20260425-godot-player.md](20260425-godot-player.md)
+
+- Status: superseded — not being built
 - Deciders: V-Sekai, fire
 - Tags: V-Sekai, Threejs, WebGPU, WebTransport, ZoneServer, Client, 20260425-threejs-webgpu-zone-client
 


### PR DESCRIPTION
## Summary

- **Three.js designs superseded — not being built.** `20260425-threejs-webgpu-zone-client.md`, `20260425-threejs-observer.md`, and `20260425-threejs-player.md` are explicitly marked superseded by the Godot native observer/player path. Status fields normalized so frontmatter and body agree.
- **Observer deferred; VR is the active focus.** `20260425-godot-observer.md` and `20260425-headless-test-matrix.md` are now \`Status: deferred\`. \`20260425-godot-player.md\` is no longer gated on the observer — VR ships first.
- **Playwright dropped from active design.** `20260425-build-cache-test-pipeline.md` and `20260425-headless-test-matrix.md` rewritten around shell-based orchestration (\`ubuntu:24.04\` + \`bash run_matrix.sh\`); branch protection trimmed to GO/GP/GO+GP. Historical Playwright PoC in `20260425-godot-web-client-webtransport.md` left intact with a deferral note at the top.
- **Downstream ADRs adapted.** `20260425-jellyfish-game.md` client strategy, \"In Core\" list, and `20260425-dual-client-test.md` (now superseded by the headless test matrix) updated to match.

## Test plan

- [ ] Read each updated ADR and confirm Status fields and supersession links agree.
- [ ] Confirm log4brains renders the new \`superseded\` and \`deferred\` statuses correctly.
- [ ] Verify cross-links resolve (no 404s between ADRs).