### PR TITLE
Reserve organization digit 3 for this repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,7 @@ quarto preview         # local preview server
 - Do not hand-edit `_site/` — it is the build output.
 - Commit message style: sentence case, no `type(scope):` prefix.
   Example: `Add ADR for aria-storage replacing desync`
+- This repository numbers nothing today: decisions are dated
+  `YYYYMMDD-kebab-title.md`, not numbered. If it ever grows RFDs, they take
+  organization digit **3** and start at `3000` — see
+  `v-sekai-fabric/multiplayer-fabric-manuals`, RFD 2000.


### PR DESCRIPTION
One line in `AGENTS.md`. No file moves, because this repository numbers nothing — its 456 decisions are dated `YYYYMMDD-kebab-title.md`.

`weftspun/request-for-discussion` and `v-sekai-fabric/multiplayer-fabric-manuals` both numbered RFDs from 0000 up, each treating the space as private. It was one space, and **113 numbers named a document in both**. Both now carry an organization digit — weftspun 1, fabric 2 (weftspun/request-for-discussion#22 and v-sekai-fabric/multiplayer-fabric-manuals PR).

This repository is not part of that collision and needs no migration. Reserving the digit anyway is the cheap part: the collision happened because two repositories each picked the obvious starting number without knowing the other existed, and a repository that adds RFDs later and starts at 0000 repeats it exactly. Digit 3 means the first one starts at `3000`.

The dated ADR scheme here is unaffected and stays as it is. The two manuals repos remain separate repositories.